### PR TITLE
Setchannel et conversation naturelle

### DIFF
--- a/client/Client.js
+++ b/client/Client.js
@@ -4,6 +4,7 @@ module.exports = class extends Client {
     constructor(config) {
         super();
         this.commands = new Collection();
+        this.privatecommands = new Collection();
         this.config = config;
     }
 }

--- a/commands/conversation.js
+++ b/commands/conversation.js
@@ -1,6 +1,6 @@
 module.exports = {
     name: 'conversation',
-    description: 'Le bot envoie un MP',
+    description: 'deprecated',
     execute(message){
         message.author.send("J'vais te goumer wsh j'ai rien coder pour l'instant!")
             .then(res => {

--- a/commands/setchannel.js
+++ b/commands/setchannel.js
@@ -1,0 +1,11 @@
+const config = require('../config.js');
+
+module.exports = {
+    name: 'setchannel',
+    description: 'Permet les commandes complexes dans un channel',
+    execute(message){
+        const args = message.content.slice(config.prefix.length).split(/ +/);
+        config.channels.push(message.channel.id.toString());
+        message.reply("done");
+    }
+}

--- a/config.js
+++ b/config.js
@@ -2,4 +2,5 @@ module.exports = {
 	discord_token: process.env.DISCORD_TOKEN,
 	api_url: process.env.API_URL,
 	prefix: "€",
+	channels: [],
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,14 @@ for (const file of commandFiles){
     const command = require(`./commands/${file}`);
     client.commands.set(command.name, command);
 }
+
+const privateCommandFiles = fs.readdirSync('./privatecommands').filter(file => file.endsWith(".js"));
+for (const file of privateCommandFiles){
+    const privateCommand = require(`./privatecommands/${file}`);
+    client.privatecommands.set(privateCommand.name, privateCommand);
+}
 console.log(client.commands);
+console.log(client.privatecommands);
 
 client.once('ready', () => {
     console.log("ready!");
@@ -27,11 +34,21 @@ client.once('disconnect', () => {
 })
 
 client.on("message", async message => {
-
     if(message.author.bot || !message.content.startsWith(config.prefix)){
+        if(config.channels.indexOf(message.channel.id.toString()) !== undefined && !message.author.bot){
+            if(message.content.endsWith("?")){
+                let pcommandName = "question";
+                let pcommand = client.privatecommands.get(pcommandName);
+                pcommand.execute(message);
+            } else {
+                // let pcommandName = "autre";
+                // let pcommand = client.privatecommands.get(pcommandName);
+                // pcommand.execute(message);
+            }
+        }
         return;
     }
-    const args = message.content.slice(config.prefix.length).split(/ +/);
+    let args = message.content.slice(config.prefix.length).split(/ +/);
     const commandName = args.shift().toLowerCase();
     const command = client.commands.get(commandName);
     try {

--- a/privatecommands/question.js
+++ b/privatecommands/question.js
@@ -1,0 +1,14 @@
+const connaissances = require("../interface/connaissances");
+
+module.exports = {
+    name: "question",
+    description: "Question version naturelle",
+    async execute(message){
+        let data = {
+            content: message.content.toString()
+        }
+        const res = await connaissances.postQuestion(data);
+        const reply = res.data;
+        message.reply(reply.word.word)
+    }
+}


### PR DESCRIPTION
Permet de mettre un channel en mode avancé qui permet de faire de demander des question de façon naturel
Exemple après un €setchannel:

```
Maxime : Est-ce que tomate est plante?
Bot : planter
```

on peut bien voir que il n'y a pas de commandes associé ( pas de €r ou €q )
PS : avec les changement d'API je sais pas si €r et €q fonctionne encore et je sais pas si je vais continuer de les supporter
(ok sa fait aucun sens mais j'ai que sa et des relations sur planter)